### PR TITLE
Add an option to auto-detect source language

### DIFF
--- a/source/website/src/components/Subtitles.vue
+++ b/source/website/src/components/Subtitles.vue
@@ -487,8 +487,8 @@ export default {
   methods: {
     getCustomVocabularyFailedReason: async function() {
       if (this.customVocabularySelected !== "") {
-        
-        console.log("Getting failed vocabulary details for " + this.customVocabularySelected)  
+
+        console.log("Getting failed vocabulary details for " + this.customVocabularySelected)
 
         let apiName = 'mieWorkflowApi'
         let path = 'service/transcribe/get_vocabulary'
@@ -500,10 +500,10 @@ export default {
             body: body,
             response: true
         };
-        
+
         try {
           let response = await this.$Amplify.API.post(apiName, path, requestOpts);
-          
+
           if (response.status === 200) {
             console.log("Failed vocabulary details:")
             console.log(response.data)
@@ -519,7 +519,7 @@ export default {
               this.customVocabularyFailedReason = ''
             }
           }
-          
+
         } catch (error) {
           this.customVocabularyFailedReason = ""
           console.log(error)
@@ -732,7 +732,7 @@ export default {
       } catch (error) {
         console.log(error)
       }
-      
+
     },
     getAssetWorkflowStatus: async function() {
       let apiName = 'mieWorkflowApi'
@@ -761,8 +761,8 @@ export default {
       try {
         let response = await this.$Amplify.API.get(apiName, path, requestOpts);
         console.log(response.data)
-        this.sourceLanguageCode = response.data.Configuration.Translate.TranslateWebCaptions.SourceLanguageCode
-        this.transcribe_language_code = response.data.Configuration.AnalyzeVideo.TranscribeVideo.TranscribeLanguage
+        this.sourceLanguageCode = response.data.Globals.MetaData.TranscribeSourceLanguage.split('-')[0]
+        this.transcribe_language_code = response.data.Globals.MetaData.TranscribeSourceLanguage
         this.vocabulary_language_code = this.transcribe_language_code
         this.vocabulary_used = response.data.Configuration.AnalyzeVideo.TranscribeVideo.VocabularyName
         const operator_info = []
@@ -773,7 +773,7 @@ export default {
         }
         this.$store.commit('updateOperatorInfo', operator_info)
         this.getWebCaptions()
-      
+
       } catch (error) {
         console.log("ERROR: Failed to get transcribe language");
         console.log(error)
@@ -807,7 +807,7 @@ export default {
           } else {
             console.log("WARNING: Could not download vocabulary. Loading vocab from vuex state...")
             this.customVocabularySaved = this.unsaved_custom_vocabularies.filter(item => (item.Name === this.customVocabularySelected))[0].vocabulary
-          }       
+          }
       } catch (error) {
         alert(
           "ERROR: Failed to get vocabularies."
@@ -849,7 +849,7 @@ export default {
             console.log("Workflow resumed")
             this.saveNotificationMessage += " and workflow resumed"
             this.pollWorkflowStatus()
-          }      
+          }
       } catch (error) {
         alert(
           "ERROR: Failed to restart workflow."
@@ -915,7 +915,7 @@ export default {
           body: data,
           queryStringParameters: {} // optional
       };
-      
+
       try {
         let response = await this.$Amplify.API.post(apiName, path, requestOpts);
         //console.log("Media assigned asset id: " + asset_id);
@@ -1068,7 +1068,7 @@ export default {
             'Content-Type': 'application/json'
           },
           body: {
-            "S3Bucket": this.DATAPLANE_BUCKET, 
+            "S3Bucket": this.DATAPLANE_BUCKET,
             "S3Key":this.customVocabularyName
             },
           response: true
@@ -1128,11 +1128,11 @@ export default {
       console.log("this.webCaptions")
       console.log(JSON.stringify(this.webCaptions))
       let data={
-        "OperatorName": operator_name, 
-        "Results": webCaptions, 
+        "OperatorName": operator_name,
+        "Results": webCaptions,
         "WorkflowId": this.workflow_id
       }
-      
+
       let apiName = 'mieDataplaneApi'
       let path = 'metadata/' + this.asset_id
       let requestOpts = {

--- a/source/website/src/views/UploadToAWSS3.vue
+++ b/source/website/src/views/UploadToAWSS3.vue
@@ -404,8 +404,9 @@ export default {
       parallelData: [],
       parallelDataList: [],
       existingSubtitlesFilename: "",
-      transcribeLanguage: "en-US",
+      transcribeLanguage: "auto",
       transcribeLanguages: [
+        {text: '(auto detect)', value: 'auto'},
         {text: 'Arabic, Gulf', value: 'ar-AE'},
         {text: 'Arabic, Modern Standard', value: 'ar-SA'},
         {text: 'Chinese Mandarin', value: 'zh-CN'},
@@ -708,12 +709,12 @@ export default {
       const TransformText = {
         WebToSRTCaptions: {
           MediaType: "MetadataOnly",
-          TargetLanguageCodes: Object.values(this.selectedTranslateLanguages.map(x => x.text)).filter(x => x !== this.sourceLanguageCode).concat(this.sourceLanguageCode),
+          TargetLanguageCodes: Object.values(this.selectedTranslateLanguages.map(x => x.text)).filter(x => x !== this.sourceLanguageCode),
           Enabled: this.enabledOperators.includes("Transcribe") || this.enabledOperators.includes("Translate")
         },
         WebToVTTCaptions: {
           MediaType: "MetadataOnly",
-          TargetLanguageCodes: Object.values(this.selectedTranslateLanguages.map(x => x.text)).filter(x => x !== this.sourceLanguageCode).concat(this.sourceLanguageCode),
+          TargetLanguageCodes: Object.values(this.selectedTranslateLanguages.map(x => x.text)).filter(x => x !== this.sourceLanguageCode),
           Enabled: this.enabledOperators.includes("Transcribe") || this.enabledOperators.includes("Translate")
         },
         PollyWebCaptions: {


### PR DESCRIPTION
*Issue #, if available:*

#208

*Description of changes:*

This PR adds an option to enable source language auto-detection in the Transcribe operator, and it enables that option in the default workflow configuration.

Depends on awslabs/aws-media-insights-engine#621

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
