### PR TITLE
Download captions before video

### DIFF
--- a/source/website/src/views/Analysis.vue
+++ b/source/website/src/views/Analysis.vue
@@ -121,7 +121,9 @@
               v-if="
                 videoOptions.sources[0].src === '' ||
                   (videoOptions.captions.length > 0 &&
-                    videoOptions.captions.length !== num_caption_tracks)
+                    videoOptions.captions.length !== num_caption_tracks) ||
+                  (videoOptions.captions.length > 0 &&
+                    videoOptions.captions[0].lang === '')
               "
             >
               <Loading />


### PR DESCRIPTION
*Issue #, if available:*

Closes #238 

*Description of changes:*

This PR will show Loading spinner instead of the video player until captions are fully downloaded, so that captions consistently load properly in the video player.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
