### PR TITLE
fix xpath for Save Edits button

### DIFF
--- a/test/e2e/test_workflow_reprocess.py
+++ b/test/e2e/test_workflow_reprocess.py
@@ -81,7 +81,7 @@ def test_workflow_reprocess(browser, workflow_to_modify, testing_env_variables):
     # Save edits
     time.sleep(1)
     # Save edits
-    browser.find_element_by_xpath("/html/body/div/div/div[2]/div/div[1]/div[2]/div/div/button[3]").click()
+    browser.find_element_by_xpath("/html/body/div/div/div[2]/div/div[1]/div[2]/div/div/button[2]").click()
     time.sleep(5)
     # Confirm Save Edits
     #browser.find_elements_by_link_text("Confirm")[0].click()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

xpath for Save Edits button has changed. Probably it changed when we last added the SRT option to the Download dropdown.

This PR fixes the e2e to use the correct xpath for Save Edits.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
